### PR TITLE
Fix Load Order Issue

### DIFF
--- a/lib/active_job/limiter.rb
+++ b/lib/active_job/limiter.rb
@@ -2,7 +2,6 @@
 
 require 'active_job/limiter/version'
 require 'active_support/dependencies/autoload'
-require 'active_job/limiter/railtie' if defined?(Rails)
 
 module ActiveJob
   module Limiter
@@ -55,3 +54,5 @@ module ActiveJob
     end
   end
 end
+
+require 'active_job/limiter/railtie' if defined?(Rails)


### PR DESCRIPTION
I believe requiring `'active_job/limiter/railtie'` before `autoload :Mixin` is causing the gem to fail on `lib/active_job/limiter/railtie.rb:10`.