### PR TITLE
Always use queue_adapter_by_class

### DIFF
--- a/activejob-limiter.gemspec
+++ b/activejob-limiter.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activejob', '>= 5.1.6.1'
   spec.add_dependency 'activesupport', '>= 5.1.6.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.16.4'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'rubocop'

--- a/lib/active_job/limiter.rb
+++ b/lib/active_job/limiter.rb
@@ -21,24 +21,7 @@ module ActiveJob
       end
 
       def queue_adapter(job)
-        if job.class.respond_to? :queue_adapter_name
-          # Rails >= 5.2
-          queue_adapter_by_name(job)
-        else
-          # Rails < 5.2
-          queue_adapter_by_class(job)
-        end
-      end
-
-      def queue_adapter_by_name(job)
-        case job.class.queue_adapter_name
-        when 'test'
-          ActiveJob::Limiter::QueueAdapters::TestAdapter
-        when 'sidekiq'
-          ActiveJob::Limiter::QueueAdapters::SidekiqAdapter
-        else
-          raise UnsupportedActiveJobLimiterQueueAdapter
-        end
+        queue_adapter_by_class(job)
       end
 
       def queue_adapter_by_class(job)


### PR DESCRIPTION
queue_adapter_by_class will correctly have test_adapter for tests
whereas queue_adapter_by_name will have what the queue adapter "should"
be e.g.:
```
(byebug) job.class.queue_adapter_name
"sidekiq"
(byebug) job.class.queue_adapter.class.name
ActiveJob::QueueAdapters::TestAdapter
```