### PR TITLE
Add support for custom test ActiveJob::QueueAdapters

### DIFF
--- a/lib/active_job/limiter.rb
+++ b/lib/active_job/limiter.rb
@@ -26,7 +26,7 @@ module ActiveJob
 
       def queue_adapter_by_class(job)
         case job.class.queue_adapter.class.name
-        when 'ActiveJob::QueueAdapters::TestAdapter'
+        when /TestAdapter$/
           ActiveJob::Limiter::QueueAdapters::TestAdapter
         when 'ActiveJob::QueueAdapters::SidekiqAdapter'
           ActiveJob::Limiter::QueueAdapters::SidekiqAdapter


### PR DESCRIPTION
This is needed for `ActiveJob::SimplePubSubFriendlyTestHelper` undevelopment in the main repo.

See https://github.flexport.io/flexport/flexport/pull/61267