### PR TITLE
Add resource-based job throttling to activejob limiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 /tmp/
 /.rspec_status
 /Gemfile.lock
-
+.byebug_history

--- a/activejob-limiter.gemspec
+++ b/activejob-limiter.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activejob', '>= 5.1.6.1'
   spec.add_dependency 'activesupport', '>= 5.1.6.1'
 
+  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'rubocop'

--- a/lib/active_job/limiter.rb
+++ b/lib/active_job/limiter.rb
@@ -20,6 +20,10 @@ module ActiveJob
         queue_adapter(job).clear_lock_before_perform(job)
       end
 
+      def acquire_throttle_lock(job, expiration, resource_id, is_retry:)
+        queue_adapter(job).acquire_throttle_lock(job, expiration, resource_id, is_retry: is_retry)
+      end
+
       def queue_adapter(job)
         queue_adapter_by_class(job)
       end

--- a/lib/active_job/limiter.rb
+++ b/lib/active_job/limiter.rb
@@ -24,8 +24,8 @@ module ActiveJob
         queue_adapter(job).acquire_lock_for_job_resource(name, expiration, job, resource_id)
       end
 
-      def release_lock_for_job_resource(name, expiration, job, resource_id)
-        queue_adapter(job).release_lock_for_job_resource(name, expiration, job, resource_id)
+      def release_lock_for_job_resource(name, job, resource_id)
+        queue_adapter(job).release_lock_for_job_resource(name, job, resource_id)
       end
 
       def queue_adapter(job)

--- a/lib/active_job/limiter.rb
+++ b/lib/active_job/limiter.rb
@@ -20,8 +20,12 @@ module ActiveJob
         queue_adapter(job).clear_lock_before_perform(job)
       end
 
-      def acquire_throttle_lock(job, expiration, resource_id, is_retry:)
-        queue_adapter(job).acquire_throttle_lock(job, expiration, resource_id, is_retry: is_retry)
+      def acquire_lock_for_job_resource(name, expiration, job, resource_id)
+        queue_adapter(job).acquire_lock_for_job_resource(name, expiration, job, resource_id)
+      end
+
+      def release_lock_for_job_resource(name, expiration, job, resource_id)
+        queue_adapter(job).release_lock_for_job_resource(name, expiration, job, resource_id)
       end
 
       def queue_adapter(job)

--- a/lib/active_job/limiter/mixin.rb
+++ b/lib/active_job/limiter/mixin.rb
@@ -29,6 +29,27 @@ module ActiveJob
             ActiveJob::Limiter.clear_lock_before_perform(job)
           end
         end
+
+        def throttle_job(expiration:, resource_key:)
+          resource_id = job.arguments[resource_key]
+          around_enqueue do |job, block|
+            if ActiveJob::Limiter.acquire_throttle_lock(job, expiration, resource_id)
+              # If we acquire the main throttle lock, we can immediate proceed
+              block.call
+            elsif ActiveJob::Limiter.acquire_throttle_retry_lock(job, expiration, resource_id)
+              # We can't acquire the main lock, but we could acquire the retry lock. That means this
+              # job-resource has been scheduled at least twice. To ensure we don't drop high-
+              # frequency updates, schedule this job to run a bit later, so that it can capture any
+              # high-frequency changes that are occuring.
+              ActiveJob::Limiter.reschedule_job_for_future(job, expiration)
+            else
+              # If neither lock can be acquired (main or retry) that means this job has ran once
+              # during the throttle period, and also attempted to run again and was rescheduled for
+              # the future. In that case, we can drop the job.
+              job.job_id = nil
+            end
+          end
+        end
       end
     end
   end

--- a/lib/active_job/limiter/mixin.rb
+++ b/lib/active_job/limiter/mixin.rb
@@ -30,6 +30,16 @@ module ActiveJob
           end
         end
 
+        # The general philosophy behind the implementation of throttle_job is that it is safe to
+        # drop duplicate jobs if and only if we know that an equivalent job will execute in the near
+        # future. There are two cases where this is true. 1) from the time a job is enqueued up
+        # until immediately before it is performed, we can safely drop subsequent enqueues knowing
+        # that an equivalent job is in the queue about to execute. 2) on the second perform of a job
+        # we delay performing until 1.25*duration time later. By doing this, we can continue to drop
+        # jobs until the end of the currently held perform lock, which we know will expire sooner
+        # than 1.25*duration. This allows us to throttle jobs without inducing artificial latency
+        # on the initial invocation, with the tradeoff being that, in order to ensure we don't
+        # unsafely drop jobs, we might still execute them once more than necessary.
         def throttle_job(duration:, extract_resource_id:, metrics_hook: ->(_result, _job) {})
           active_job_limiter_add_throttle_job_around_enqueue(
             duration: duration,
@@ -60,6 +70,10 @@ module ActiveJob
               block.call
               metrics_hook.call('enqueue.enqueued', job)
             else
+              # If we get here, that means that an equivalent job has been enqueued, but has not yet
+              # been performed (because it always releases the enqueue lock before performing). That
+              # means that it is safe to drop jobs here because we know an equivalent job will start
+              # executing at some point in the near future.
               job.job_id = nil
               metrics_hook.call('enqueue.dropped', job)
             end
@@ -70,18 +84,27 @@ module ActiveJob
           around_perform do |job, block|
             resource_id = extract_resource_id.call(job)
 
+            # Before we start executing, allow new jobs to be enqueued
             # see around_enqueue above -- for enqueue related locks we must namespace by queue_name
             enqueue_resource_id = "#{resource_id}:#{job.queue_name}"
+            ActiveJob::Limiter.release_lock_for_job_resource('enqueue', job, enqueue_resource_id)
 
             if ActiveJob::Limiter.acquire_lock_for_job_resource('perform', duration, job, resource_id)
-              # Before we start executing, allow new jobs to be enqueued
-              ActiveJob::Limiter.release_lock_for_job_resource('enqueue', job, enqueue_resource_id)
               block.call
               metrics_hook.call('perform.performed', job)
             elsif ActiveJob::Limiter.acquire_lock_for_job_resource('reschedule', duration, job, resource_id)
+              # If we get here, then that means an equivalent job either is still performing or
+              # recently performed. In order to respect the throttle without losing data, we create
+              # our own destiny by rescheduling a job in the near future. By doing do, it becomes
+              # safe to start dropping jobs until the current perform lock expires. The retry is
+              # scheduled for a point in time after the perform lock expires, so it will not be
+              # dropped (unless it is contending with even more future duplicates... which is fine.
+              # Either way, one will win and execute).
               self.class.send(:active_job_limiter_reschedule_job_for_later, job, duration)
               metrics_hook.call('perform.rescheduled', job)
             else
+              # See above -- if we get here, we know a job has been scheduled in the future, so it
+              # is safe to drop jobs until the current perform lock has expired.
               job.job_id = nil
               metrics_hook.call('perform.dropped', job)
             end
@@ -91,9 +114,15 @@ module ActiveJob
         def active_job_limiter_reschedule_job_for_later(existing_job, lock_duration)
           new_job = existing_job.class.new(*existing_job.arguments)
 
-          # Rescheduled jobs need to pass through around_enqueue without being dropped, so we
-          # need to sneakily signal that this job should be let through regardless of the
-          # current lock
+          # Rescheduled jobs need to pass through around_enqueue without being dropped, so we need
+          # to sneakily signal that this job should be let through regardless of the current lock.
+          # One might think that it if a job is already in the queue, then it should be fine to drop
+          # the reschedule, but that is not the case. At this point, both the perform lock and the
+          # retry lock have been acquired, so if there is a job already enqueued, it will probably
+          # be dropped as soon as it is performed. For that reason, in order to stick to the policy
+          # of only dropping jobs if we have guaranteed that an equivalent job will execute in the
+          # near future, special care must be taken to ensure that our reschedule here passes safely
+          # through the around_enqueue hook.
           new_job.instance_variable_set(:@bypass_active_job_limiter_enqueue_locks, true)
 
           # Using a 1.25x multiplier to account for clock skew between server and redis. 1.25 was

--- a/lib/active_job/limiter/queue_adapters/test_adapter.rb
+++ b/lib/active_job/limiter/queue_adapters/test_adapter.rb
@@ -12,15 +12,7 @@ module ActiveJob
           true
         end
 
-        def acquire_throttle_lock(_job, _expiration, _resource_id)
-          true
-        end
-
-        def acquire_throttle_retry_lock(_job, _expiration, _resource_id)
-          true
-        end
-
-        def reschedule_job_for_future(_job, _expiration)
+        def acquire_throttle_lock(_job, _expiration, _resource_id, _is_retry:)
           true
         end
       end

--- a/lib/active_job/limiter/queue_adapters/test_adapter.rb
+++ b/lib/active_job/limiter/queue_adapters/test_adapter.rb
@@ -12,7 +12,11 @@ module ActiveJob
           true
         end
 
-        def acquire_throttle_lock(_job, _expiration, _resource_id, _is_retry:)
+        def self.acquire_lock_for_job_resource(_name, _expiration, _job, _resource_id)
+          true
+        end
+
+        def self.release_lock_for_job_resource(_name, _expiration, _job, _resource_id)
           true
         end
       end

--- a/lib/active_job/limiter/queue_adapters/test_adapter.rb
+++ b/lib/active_job/limiter/queue_adapters/test_adapter.rb
@@ -16,7 +16,7 @@ module ActiveJob
           true
         end
 
-        def self.release_lock_for_job_resource(_name, _expiration, _job, _resource_id)
+        def self.release_lock_for_job_resource(_name, _job, _resource_id)
           true
         end
       end

--- a/lib/active_job/limiter/queue_adapters/test_adapter.rb
+++ b/lib/active_job/limiter/queue_adapters/test_adapter.rb
@@ -11,6 +11,18 @@ module ActiveJob
         def self.clear_lock_before_perform(_job)
           true
         end
+
+        def acquire_throttle_lock(_job, _expiration, _resource_id)
+          true
+        end
+
+        def acquire_throttle_retry_lock(_job, _expiration, _resource_id)
+          true
+        end
+
+        def reschedule_job_for_future(_job, _expiration)
+          true
+        end
       end
     end
   end

--- a/spec/active_job/limiter_spec.rb
+++ b/spec/active_job/limiter_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ActiveJob::Limiter do
         .with(instance_of(LimitedJob), expiration_time).and_return(false)
       expect(ActiveJob::Limiter).to_not receive(:clear_lock_before_perform)
       job = LimitedJob.perform_later
-      expect(job == false || job.job_id == nil).to be true
+      expect(job == false || job.job_id.nil?).to be true
     end
   end
 
@@ -60,13 +60,13 @@ RSpec.describe ActiveJob::Limiter do
     it 'when the before_perform hook raises an error' do
       expect(ActiveJob::Limiter).to receive(:check_lock_before_enqueue).and_return(true)
       expect(ActiveJob::Limiter).to receive(:clear_lock_before_perform).and_raise(StandardError)
-      expect{ LimitedJob.perform_later }.to raise_error(StandardError)
+      expect { LimitedJob.perform_later }.to raise_error(StandardError)
     end
 
     it 'when the before_enqueue hook raises an error' do
       expect(ActiveJob::Limiter).to receive(:check_lock_before_enqueue).and_raise(StandardError)
       expect(ActiveJob::Limiter).to_not receive(:clear_lock_before_perform)
-      expect{ LimitedJob.perform_later }.to raise_error(StandardError)
+      expect { LimitedJob.perform_later }.to raise_error(StandardError)
     end
   end
 

--- a/spec/active_job/limiter_spec.rb
+++ b/spec/active_job/limiter_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ActiveJob::Limiter do
         .with(instance_of(LimitedJob), expiration_time).and_return(false)
       expect(ActiveJob::Limiter).to_not receive(:clear_lock_before_perform)
       job = LimitedJob.perform_later
-      expect(job.job_id).to be_nil
+      expect(job == false || job.job_id == nil).to be true
     end
   end
 

--- a/spec/active_job/limiter_throttle_spec.rb
+++ b/spec/active_job/limiter_throttle_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+RSpec.describe ActiveJob::Limiter do
+  let(:throttle_duration) { 2.minutes }
+  let(:resource_id) { '123' }
+
+  class MetricsProxy
+    def self.call(result, job); end
+  end
+
+  class ThrottledJob < ActiveJob::Base
+    include ActiveJob::Limiter::Mixin # Needed without Rails autoloading
+
+    # Same as :throttle_duration above, unable to access let()
+    throttle_job(
+      duration: 2.minutes,
+      extract_resource_id: (lambda { |job|
+        job.arguments.first
+      }),
+      metrics_hook: MetricsProxy
+    )
+
+    def perform(resource_id); end
+  end
+
+  class StandardJob < ActiveJob::Base
+    include ActiveJob::Limiter::Mixin # Needed without Rails autoloading
+
+    def perform; end
+  end
+
+  def throttle_lock_not_acquired
+    expect(ActiveJob::Limiter).to receive(:acquire_throttle_lock)
+      .with(instance_of(ThrottledJob), throttle_duration, resource_id, is_retry: false).and_return(true)
+  end
+
+  def throttle_lock_already_acquired
+    expect(ActiveJob::Limiter).to receive(:acquire_throttle_lock)
+      .with(instance_of(ThrottledJob), throttle_duration, resource_id, is_retry: false).and_return(false)
+  end
+
+  def retry_lock_not_acquired
+    expect(ActiveJob::Limiter).to receive(:acquire_throttle_lock)
+      .with(instance_of(ThrottledJob), throttle_duration, resource_id, is_retry: true).and_return(true)
+  end
+
+  def retry_lock_already_acquired
+    expect(ActiveJob::Limiter).to receive(:acquire_throttle_lock)
+      .with(instance_of(ThrottledJob), throttle_duration, resource_id, is_retry: true).and_return(false)
+  end
+
+  def job_should_be_performed
+    expect_any_instance_of(ThrottledJob).to receive(:perform).with(resource_id)
+  end
+
+  def job_should_not_be_performed
+    expect_any_instance_of(ThrottledJob).to_not receive(:perform).with(resource_id)
+  end
+
+  def new_job_should_be_enqueued(&blk)
+    expect(blk).to change { enqueued_jobs.size  }.by(1)
+  end
+
+  def new_job_should_be_not_enqueued(&blk)
+    expect(blk).to change { enqueued_jobs.size  }.by(0)
+  end
+
+  def expect_metric(result)
+    expect(MetricsProxy).to receive(:call).with(
+      result,
+      instance_of(ThrottledJob)
+    )
+  end
+
+  context 'the job has not yet run during the throttle period' do
+    before :each do
+      throttle_lock_not_acquired
+    end
+
+    it 'performs the job' do
+      job_should_be_performed
+      expect_metric(:performed)
+
+      ThrottledJob.perform_later(resource_id)
+    end
+  end
+
+  context 'the job has run one time already' do
+    before :each do
+      throttle_lock_already_acquired
+    end
+
+    context 'a retry has not been scheduled' do
+      before :each do
+        retry_lock_not_acquired
+      end
+
+      it 'enqueues a job for the future' do
+        job_should_not_be_performed
+        expect_metric(:rescheduled)
+
+        new_job_should_be_enqueued do
+          ThrottledJob.perform_later(resource_id)
+        end
+      end
+    end
+
+    context 'a retry has been scheduled' do
+      before :each do
+        retry_lock_already_acquired
+      end
+
+      it 'does nothing' do
+        job_should_not_be_performed
+        expect_metric(:dropped)
+
+        new_job_should_be_not_enqueued do
+          ThrottledJob.perform_later(resource_id)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ RSpec.configure do |config|
   config.before(:all) do
     ActiveJob::Base.queue_adapter = :test
     ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
   end
 
   config.before(:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'bundler/setup'
 require 'active_job'
 require 'active_job/limiter'
+require 'byebug'
 
 RSpec.configure do |config|
   config.include(ActiveJob::TestHelper)
@@ -15,7 +16,6 @@ RSpec.configure do |config|
 
   config.before(:each) do
     ActiveJob::Base.queue_adapter.performed_jobs = []
-    allow($stdout).to receive(:write)
   end
 
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
This PR adds a new `throttle_job` macro which deduplicates jobs by resource and tries to have good latency and correctnes at the same time. It does this by using locks at both enqueue-time and perform-time.

An example of a solution that would have bad latency but good correctness: artifically delaying execution by `duration`, and disallow duplicates in the queue. This will cause a delay in all cases, which might not be desirable if a user is waiting.

An example of a solution that would have good latency but bad correctness: dropping all jobs if they are enqueued within `duration` of the start of an identical job. Sometimes it is possible that seperate changes do happen with relatively high frequency, and they might not be "seen" by the first job.

How this PR does it:

At enqueue time, we employ near-identical techniques as `limit_queue`. That is, a job holds a lock from the time it is enqueued until right before it is performed. This can help prevent duplicate jobs that occur very close together, but if the queue is empty, then a job will spend an extremely small amount of time in this period. So it is not a concurrency gaurantee by any means, but is a handy way to drop duplicate jobs without worring about "losing" anything (assuming the job is idempotent).

At perform time, a lock is acquired and never released. Instead it expires after the specified duration. As long as the job doesn't run for longer than the specified duration, this should provide a pretty good gaurantee that a job will never run more frequently than once every `duration`.

The behavior for subsequent duplicate jobs at perform time (which can occur if the job is relatively slow to run -- as soon as it leaves the queue, an equivelant job can enter they queue, and attempt to execute at perform time) is as follows:

- on the first dupe, another lock is acquired, known as the reschedule lock. The job is not performed, but instead rescheduled for a future time (`1.1 * duration`). The lock is still only held for `duration` though.
- every subsequent duplicate job is dropped. We can do this with confidence, since we knows that an identical job has been scheduled for the near future.

**tl;dr: this method will only drop a job if it is gauranteed that an equivelent job is enqueued but has not yet began execution. It artificially enqueues future jobs so that this is true more often. The worst case scenario is that n duplicate jobs will result in either 1 or 2 job invocations**.

To use, add something like this to your job class:

```ruby
throttle_job(
      duration: 2.minutes,
      extract_resource_id: (lambda { |job|
        job.arguments.first
      }),
```

There is an optional argument, metrics_hook, which will be fired and provided with information about what happened to the job (e.g. was it dropped at enqueue time? Was it enqueued, but dropped at perform time? etc.) I intend to use this to monitor a production roll out.