### PR TITLE
Add debounce_job primitive (v0.2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /.rspec_status
 /Gemfile.lock
 .byebug_history
+/.idea

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Calls to `perform_later` will succeed even though the job was not enqueued, howe
 execution fires, and only after `duration` has elapsed since the *last* trigger. 
 
 ```ruby
-class IndexUserJob < ActiveJob::Base
+class DebouncedJob < ActiveJob::Base
   debounce_job(
     duration: 30.seconds,
     extract_resource_id: (lambda { |job|
@@ -60,20 +60,9 @@ class IndexUserJob < ActiveJob::Base
 end
 ```
 
-**Notes:**
-
-- `perform_later` returns a job object whose `job_id` is `nil` — the caller's invocation is always
-  coalesced and never lands in the queue directly. An internal delayed job does the work.
-- `metrics_hook` (optional `Proc`) is called with a result string and the job instance:
-  - `'enqueue.scheduled'` — first trigger, internal delayed job enqueued.
-  - `'enqueue.coalesced'` — subsequent trigger dropped; a delayed job already covers it.
-  - `'perform.performed'` — target time reached, user's `perform` executed.
-  - `'perform.rescheduled'` — target was extended by a newer trigger; job rescheduled.
-- Sidekiq is the only supported queue adapter (same as `throttle_job`).
-
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Run `bin/redis` to start Redis in Docker, keep it running. Then, in separate terminal, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,44 @@ The expiration time is how long additional enqueue attempts will be dropped. Wit
 
 Calls to `perform_later` will succeed even though the job was not enqueued, however the job_id on the returned object will be set to nil to indicate that the enqueuing did not happen.
 
+### Debouncing Jobs
+
+`debounce_job` provides trailing-edge debounce semantics: for any burst of triggers, exactly one
+execution fires, and only after `duration` has elapsed since the *last* trigger. This is the right
+primitive for "execute once after the burst settles" workflows — e.g. re-indexing a record after
+a rapid sequence of updates, or collapsing a webhook flood into a single reconcile pass.
+
+Every call to `perform_later` is treated as a trigger rather than a direct enqueue. The first
+trigger in a burst schedules a single internal delayed job `duration` in the future. Subsequent
+triggers within that window extend the target time in Redis and are coalesced — no additional
+Sidekiq job is created. When the scheduled job wakes up, it checks the target time atomically: if
+no newer trigger extended it, the job executes; otherwise it reschedules itself for the remaining
+wait.
+
+```ruby
+class IndexUserJob < ActiveJob::Base
+  debounce_job(
+    duration: 30.seconds,
+    extract_resource_id: ->(job) { job.arguments.first }
+  )
+
+  def perform(user_id)
+    # runs once, after the burst of triggers settles
+  end
+end
+```
+
+**Notes:**
+
+- `perform_later` returns a job object whose `job_id` is `nil` — the caller's invocation is always
+  coalesced and never lands in the queue directly. An internal delayed job does the work.
+- `metrics_hook` (optional `Proc`) is called with a result string and the job instance:
+  - `'enqueue.scheduled'` — first trigger, internal delayed job enqueued.
+  - `'enqueue.coalesced'` — subsequent trigger dropped; a delayed job already covers it.
+  - `'perform.performed'` — target time reached, user's `perform` executed.
+  - `'perform.rescheduled'` — target was extended by a newer trigger; job rescheduled.
+- Sidekiq is the only supported queue adapter (same as `throttle_job`).
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -43,26 +43,19 @@ Calls to `perform_later` will succeed even though the job was not enqueued, howe
 ### Debouncing Jobs
 
 `debounce_job` provides trailing-edge debounce semantics: for any burst of triggers, exactly one
-execution fires, and only after `duration` has elapsed since the *last* trigger. This is the right
-primitive for "execute once after the burst settles" workflows — e.g. re-indexing a record after
-a rapid sequence of updates, or collapsing a webhook flood into a single reconcile pass.
-
-Every call to `perform_later` is treated as a trigger rather than a direct enqueue. The first
-trigger in a burst schedules a single internal delayed job `duration` in the future. Subsequent
-triggers within that window extend the target time in Redis and are coalesced — no additional
-Sidekiq job is created. When the scheduled job wakes up, it checks the target time atomically: if
-no newer trigger extended it, the job executes; otherwise it reschedules itself for the remaining
-wait.
+execution fires, and only after `duration` has elapsed since the *last* trigger. 
 
 ```ruby
 class IndexUserJob < ActiveJob::Base
   debounce_job(
     duration: 30.seconds,
-    extract_resource_id: ->(job) { job.arguments.first }
+    extract_resource_id: (lambda { |job|
+      job.arguments.first
+    }),
   )
 
-  def perform(user_id)
-    # runs once, after the burst of triggers settles
+  def perform(model_id)
+    [...]
   end
 end
 ```

--- a/activejob-limiter.gemspec
+++ b/activejob-limiter.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'sidekiq', '~> 6.4.2'
+  spec.add_development_dependency 'redis',   '~> 4.7.1'
 end

--- a/bin/docker-compose.yml
+++ b/bin/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6389:6379"
+    command: ["redis-server", "--save", "", "--appendonly", "no"]

--- a/bin/redis
+++ b/bin/redis
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+DIR="$(dirname "$0")"
+docker compose -f "$DIR/docker-compose.yml" up redis

--- a/lib/active_job/limiter.rb
+++ b/lib/active_job/limiter.rb
@@ -28,6 +28,14 @@ module ActiveJob
         queue_adapter(job).release_lock_for_job_resource(name, job, resource_id)
       end
 
+      def register_debounce_trigger(job, duration, resource_id)
+        queue_adapter(job).register_debounce_trigger(job, duration, resource_id)
+      end
+
+      def claim_debounce_execution(job, resource_id)
+        queue_adapter(job).claim_debounce_execution(job, resource_id)
+      end
+
       def queue_adapter(job)
         queue_adapter_by_class(job)
       end

--- a/lib/active_job/limiter/mixin.rb
+++ b/lib/active_job/limiter/mixin.rb
@@ -70,7 +70,6 @@ module ActiveJob
             metrics_hook: metrics_hook
           )
           active_job_limiter_add_debounce_job_around_perform(
-            duration: duration,
             extract_resource_id: extract_resource_id,
             metrics_hook: metrics_hook
           )
@@ -158,7 +157,7 @@ module ActiveJob
         # sorted set to locate it by JID.  Instead, the waker always wakes up and checks the
         # quiet_until epoch atomically: if the quiet period has passed it executes; otherwise it
         # re-enqueues itself for the remaining wait (O(1) Redis read + one Sidekiq push).
-        def active_job_limiter_add_debounce_job_around_perform(duration:, extract_resource_id:, metrics_hook:)
+        def active_job_limiter_add_debounce_job_around_perform(extract_resource_id:, metrics_hook:)
           around_perform do |job, block|
             resource_id = extract_resource_id.call(job)
             claim = ActiveJob::Limiter.claim_debounce_execution(job, resource_id)

--- a/lib/active_job/limiter/mixin.rb
+++ b/lib/active_job/limiter/mixin.rb
@@ -56,7 +56,7 @@ module ActiveJob
         # The debounce_job primitive provides trailing-edge debounce semantics: for any burst of
         # triggers (perform_later calls), exactly one execution fires, and only after `duration`
         # has elapsed since the last trigger. This is the correct primitive for "execute once after
-        # the burst settles" workflows (e.g. re-indexing after rapid model updates).
+        # the burst settles" workflows (e.g. emit single event after rapid model updates).
         #
         # Every perform_later call is coalesced rather than enqueued directly. The first trigger in
         # a burst schedules a single internal delayed job for `duration` later. Subsequent triggers
@@ -140,9 +140,11 @@ module ActiveJob
               block.call
             else
               resource_id = extract_resource_id.call(job)
+              # Setting job_id to nil signals ActiveJob to skip the actual enqueue; the caller's
+              # perform_later call is coalesced — an internal delayed job does the real work.
               job.job_id = nil
               if ActiveJob::Limiter.register_debounce_trigger(job, duration, resource_id)
-                self.class.send(:active_job_limiter_schedule_debounce_job, job, duration)
+                self.class.send(:active_job_limiter_enqueue_debounce_job, job, duration)
                 metrics_hook.call('enqueue.scheduled', job)
               else
                 metrics_hook.call('enqueue.coalesced', job)
@@ -151,28 +153,27 @@ module ActiveJob
           end
         end
 
+        # On perform, we check Redis rather than cancelling and rescheduling the Sidekiq job on
+        # every new trigger.  Cancelling a scheduled Sidekiq job requires an O(N) scan of the
+        # sorted set to locate it by JID.  Instead, the waker always wakes up and checks the
+        # quiet_until epoch atomically: if the quiet period has passed it executes; otherwise it
+        # re-enqueues itself for the remaining wait (O(1) Redis read + one Sidekiq push).
         def active_job_limiter_add_debounce_job_around_perform(duration:, extract_resource_id:, metrics_hook:)
           around_perform do |job, block|
             resource_id = extract_resource_id.call(job)
-            result = ActiveJob::Limiter.claim_debounce_execution(job, resource_id)
+            claim = ActiveJob::Limiter.claim_debounce_execution(job, resource_id)
 
-            if result == :execute
+            if claim.is_claimed
               block.call
               metrics_hook.call('perform.performed', job)
             else
-              self.class.send(:active_job_limiter_reschedule_debounce_job_for_later, job, result)
+              self.class.send(:active_job_limiter_enqueue_debounce_job, job, claim.wait_seconds)
               metrics_hook.call('perform.rescheduled', job)
             end
           end
         end
 
-        def active_job_limiter_schedule_debounce_job(existing_job, duration)
-          new_job = existing_job.class.new(*existing_job.arguments)
-          new_job.instance_variable_set(:@bypass_active_job_limiter_debounce, true)
-          new_job.enqueue(wait: duration, queue: existing_job.queue_name)
-        end
-
-        def active_job_limiter_reschedule_debounce_job_for_later(existing_job, wait)
+        def active_job_limiter_enqueue_debounce_job(existing_job, wait)
           new_job = existing_job.class.new(*existing_job.arguments)
           new_job.instance_variable_set(:@bypass_active_job_limiter_debounce, true)
           new_job.enqueue(wait: wait, queue: existing_job.queue_name)

--- a/lib/active_job/limiter/mixin.rb
+++ b/lib/active_job/limiter/mixin.rb
@@ -53,6 +53,29 @@ module ActiveJob
           )
         end
 
+        # The debounce_job primitive provides trailing-edge debounce semantics: for any burst of
+        # triggers (perform_later calls), exactly one execution fires, and only after `duration`
+        # has elapsed since the last trigger. This is the correct primitive for "execute once after
+        # the burst settles" workflows (e.g. re-indexing after rapid model updates).
+        #
+        # Every perform_later call is coalesced rather than enqueued directly. The first trigger in
+        # a burst schedules a single internal delayed job for `duration` later. Subsequent triggers
+        # during that window extend the target time in Redis and are dropped. When the scheduled job
+        # wakes up, it checks whether the target time has passed: if so it executes; otherwise it
+        # reschedules itself for the remaining wait and drops this invocation.
+        def debounce_job(duration:, extract_resource_id:, metrics_hook: ->(_result, _job) {})
+          active_job_limiter_add_debounce_job_around_enqueue(
+            duration: duration,
+            extract_resource_id: extract_resource_id,
+            metrics_hook: metrics_hook
+          )
+          active_job_limiter_add_debounce_job_around_perform(
+            duration: duration,
+            extract_resource_id: extract_resource_id,
+            metrics_hook: metrics_hook
+          )
+        end
+
         private
 
         # Prefixing private methods with active_job_limiter to avoid conflicts with user code
@@ -109,6 +132,50 @@ module ActiveJob
               metrics_hook.call('perform.dropped', job)
             end
           end
+        end
+
+        def active_job_limiter_add_debounce_job_around_enqueue(duration:, extract_resource_id:, metrics_hook:)
+          around_enqueue do |job, block|
+            if job.instance_variable_get(:@bypass_active_job_limiter_debounce)
+              block.call
+            else
+              resource_id = extract_resource_id.call(job)
+              job.job_id = nil
+              if ActiveJob::Limiter.register_debounce_trigger(job, duration, resource_id)
+                self.class.send(:active_job_limiter_schedule_debounce_job, job, duration)
+                metrics_hook.call('enqueue.scheduled', job)
+              else
+                metrics_hook.call('enqueue.coalesced', job)
+              end
+            end
+          end
+        end
+
+        def active_job_limiter_add_debounce_job_around_perform(duration:, extract_resource_id:, metrics_hook:)
+          around_perform do |job, block|
+            resource_id = extract_resource_id.call(job)
+            result = ActiveJob::Limiter.claim_debounce_execution(job, resource_id)
+
+            if result == :execute
+              block.call
+              metrics_hook.call('perform.performed', job)
+            else
+              self.class.send(:active_job_limiter_reschedule_debounce_job_for_later, job, result)
+              metrics_hook.call('perform.rescheduled', job)
+            end
+          end
+        end
+
+        def active_job_limiter_schedule_debounce_job(existing_job, duration)
+          new_job = existing_job.class.new(*existing_job.arguments)
+          new_job.instance_variable_set(:@bypass_active_job_limiter_debounce, true)
+          new_job.enqueue(wait: duration, queue: existing_job.queue_name)
+        end
+
+        def active_job_limiter_reschedule_debounce_job_for_later(existing_job, wait)
+          new_job = existing_job.class.new(*existing_job.arguments)
+          new_job.instance_variable_set(:@bypass_active_job_limiter_debounce, true)
+          new_job.enqueue(wait: wait, queue: existing_job.queue_name)
         end
 
         def active_job_limiter_reschedule_job_for_later(existing_job, lock_duration)

--- a/lib/active_job/limiter/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/limiter/queue_adapters/sidekiq_adapter.rb
@@ -52,10 +52,10 @@ module ActiveJob
           # TTL whenever it defers execution; DEBOUNCE_TTL_BUFFER provides extra headroom against
           # clock skew between the app server and Redis.
           def register_debounce_trigger(job, duration, resource_id)
-            quiet_until_key      = debounce_quiet_until_key_for(job, resource_id)
+            quiet_until_key = debounce_quiet_until_key_for(job, resource_id)
             is_job_scheduled_key = debounce_is_job_scheduled_key_for(job, resource_id)
-            new_quiet_until      = (Time.now.to_f + duration.to_f).to_s
-            ttl                  = duration.to_i + DEBOUNCE_TTL_BUFFER
+            new_quiet_until = (Time.now.to_f + duration.to_f).to_s
+            ttl = duration.to_i + DEBOUNCE_TTL_BUFFER
 
             result = Sidekiq.redis_pool.with do |conn|
               conn.eval(DEBOUNCE_TRIGGER_SCRIPT, keys: [quiet_until_key, is_job_scheduled_key], argv: [new_quiet_until, ttl])
@@ -71,7 +71,7 @@ module ActiveJob
 
             -- Always push quiet_until forward; EX = set expiration in seconds
             redis.call('SET', quiet_until_key, new_quiet_until, 'EX', ttl)
-            -- NX = only set if key does not exist; 'OK' means this caller won the scheduling slot
+            -- NX = only set if key does not exist; returns 'OK' on success, means this caller won the scheduling slot
             return redis.call('SET', is_job_scheduled_key, '1', 'NX', 'EX', ttl)
           LUA
 
@@ -80,7 +80,7 @@ module ActiveJob
           # or is_claimed: false with the remaining wait seconds if a newer trigger extended the window.
 
           def claim_debounce_execution(job, resource_id)
-            quiet_until_key      = debounce_quiet_until_key_for(job, resource_id)
+            quiet_until_key = debounce_quiet_until_key_for(job, resource_id)
             is_job_scheduled_key = debounce_is_job_scheduled_key_for(job, resource_id)
             now = Time.now.to_f
 
@@ -97,7 +97,7 @@ module ActiveJob
           DEBOUNCE_CLAIM_SCRIPT = <<~LUA.freeze
             local quiet_until_key      = KEYS[1]
             local is_job_scheduled_key = KEYS[2]
-            local now                  = ARGV[1]  -- current epoch (float as string)
+            local now                  = ARGV[1]  -- current epoch (float seconds as string)
             local ttl_buffer           = ARGV[2]  -- extra seconds added to the TTL extension
 
             local quiet_until = redis.call('GET', quiet_until_key)  -- GET returns nil if key absent

--- a/lib/active_job/limiter/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/limiter/queue_adapters/sidekiq_adapter.rb
@@ -4,28 +4,8 @@ module ActiveJob
   module Limiter
     module QueueAdapters
       module SidekiqAdapter
+        # seconds of buffer added to all debounce Redis key TTLs to absorb clock skew
         DEBOUNCE_TTL_BUFFER = 5
-
-        # Sets target time and atomically claims the scheduled slot (NX).
-        # Returns "OK" if this caller wins the slot, nil otherwise.
-        DEBOUNCE_TRIGGER_SCRIPT = <<~LUA.freeze
-          redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
-          return redis.call('SET', KEYS[2], '1', 'NX', 'EX', ARGV[2])
-        LUA
-
-        # Compares target to now. Clears keys and returns '' if ready to execute,
-        # or extends the scheduled key TTL and returns the target epoch if not yet.
-        DEBOUNCE_CLAIM_SCRIPT = <<~LUA.freeze
-          local target = redis.call('GET', KEYS[1])
-          if (not target) or (tonumber(target) <= tonumber(ARGV[1])) then
-            redis.call('DEL', KEYS[1])
-            redis.call('DEL', KEYS[2])
-            return ''
-          else
-            redis.call('EXPIRE', KEYS[2], math.ceil(tonumber(target) - tonumber(ARGV[1]) + tonumber(ARGV[2])))
-            return target
-          end
-        LUA
 
         class << self
           def check_lock_before_enqueue(job, expiration)
@@ -63,35 +43,76 @@ module ActiveJob
             end
           end
 
-          # Sets the debounce target time and atomically claims the scheduled slot if not taken.
+          # Sets the debounce quiet-until time and atomically claims the scheduled slot if not taken.
           # Returns true iff this caller is responsible for enqueuing the delayed job.
+          #
+          # TTL dynamics: we set TTL = duration + buffer on every trigger.  Each call to this method
+          # slides the quiet_until epoch forward and resets the TTL, so the keys stay alive as long
+          # as triggers keep arriving.  The claim script (below) extends the is_job_scheduled key's
+          # TTL whenever it defers execution; DEBOUNCE_TTL_BUFFER provides extra headroom against
+          # clock skew between the app server and Redis.
           def register_debounce_trigger(job, duration, resource_id)
-            target_key = debounce_target_key_for(job, resource_id)
-            scheduled_key = debounce_scheduled_key_for(job, resource_id)
-            new_target = (Time.now.to_f + duration.to_f).to_s
-            ttl = duration.to_i + DEBOUNCE_TTL_BUFFER
+            quiet_until_key      = debounce_quiet_until_key_for(job, resource_id)
+            is_job_scheduled_key = debounce_is_job_scheduled_key_for(job, resource_id)
+            new_quiet_until      = (Time.now.to_f + duration.to_f).to_s
+            ttl                  = duration.to_i + DEBOUNCE_TTL_BUFFER
 
             result = Sidekiq.redis_pool.with do |conn|
-              conn.eval(DEBOUNCE_TRIGGER_SCRIPT, keys: [target_key, scheduled_key], argv: [new_target, ttl])
+              conn.eval(DEBOUNCE_TRIGGER_SCRIPT, keys: [quiet_until_key, is_job_scheduled_key], argv: [new_quiet_until, ttl])
             end
             result == 'OK'
           end
 
-          # Atomically checks whether target time has passed. Returns :execute if it has,
-          # or the remaining Float seconds to wait if a newer trigger extended the window.
+          DEBOUNCE_TRIGGER_SCRIPT = <<~LUA.freeze
+            local quiet_until_key      = KEYS[1]  -- stores the earliest epoch at which execution is allowed
+            local is_job_scheduled_key = KEYS[2]  -- 1 iff a delayed job is already waiting in Sidekiq
+            local new_quiet_until      = ARGV[1]  -- Time.now + duration (float seconds, as string)
+            local ttl                  = ARGV[2]  -- integer seconds until both keys expire
+
+            -- Always push quiet_until forward; EX = set expiration in seconds
+            redis.call('SET', quiet_until_key, new_quiet_until, 'EX', ttl)
+            -- NX = only set if key does not exist; 'OK' means this caller won the scheduling slot
+            return redis.call('SET', is_job_scheduled_key, '1', 'NX', 'EX', ttl)
+          LUA
+
+          # Atomically checks whether the quiet-until epoch has passed.
+          # Returns a DebounceClaim with is_claimed: true if the job should execute now,
+          # or is_claimed: false with the remaining wait seconds if a newer trigger extended the window.
+
           def claim_debounce_execution(job, resource_id)
-            target_key = debounce_target_key_for(job, resource_id)
-            scheduled_key = debounce_scheduled_key_for(job, resource_id)
+            quiet_until_key      = debounce_quiet_until_key_for(job, resource_id)
+            is_job_scheduled_key = debounce_is_job_scheduled_key_for(job, resource_id)
             now = Time.now.to_f
 
             result = Sidekiq.redis_pool.with do |conn|
-              conn.eval(DEBOUNCE_CLAIM_SCRIPT, keys: [target_key, scheduled_key], argv: [now.to_s, DEBOUNCE_TTL_BUFFER.to_s])
+              conn.eval(DEBOUNCE_CLAIM_SCRIPT, keys: [quiet_until_key, is_job_scheduled_key], argv: [now.to_s, DEBOUNCE_TTL_BUFFER.to_s])
             end
 
-            return :execute if result.nil? || result.empty?
+            return DebounceClaim.new(true, 0.0) if result.nil? || result.empty?
 
-            [result.to_f - Time.now.to_f, 0.0].max
+            wait_seconds = [result.to_f - Time.now.to_f, 0.0].max
+            DebounceClaim.new(false, wait_seconds)
           end
+
+          DEBOUNCE_CLAIM_SCRIPT = <<~LUA.freeze
+            local quiet_until_key      = KEYS[1]
+            local is_job_scheduled_key = KEYS[2]
+            local now                  = ARGV[1]  -- current epoch (float as string)
+            local ttl_buffer           = ARGV[2]  -- extra seconds added to the TTL extension
+
+            local quiet_until = redis.call('GET', quiet_until_key)  -- GET returns nil if key absent
+            if (not quiet_until) or (tonumber(quiet_until) <= tonumber(now)) then
+              -- Quiet period has elapsed: clear both keys and signal execution
+              redis.call('DEL', quiet_until_key)
+              redis.call('DEL', is_job_scheduled_key)
+              return ''
+            else
+              -- A newer trigger pushed quiet_until into the future; extend the scheduled-key TTL
+              -- so it doesn't expire before we reschedule.  EXPIRE sets TTL in whole seconds.
+              redis.call('EXPIRE', is_job_scheduled_key, math.ceil(tonumber(quiet_until) - tonumber(now) + tonumber(ttl_buffer)))
+              return quiet_until
+            end
+          LUA
 
           private
 
@@ -107,14 +128,19 @@ module ActiveJob
             ActiveJob::Arguments.serialize(job.arguments).to_s
           end
 
-          def debounce_target_key_for(job, resource_id)
-            "limiter:debounce:#{job.class.name}:#{resource_id}:target"
+          def debounce_quiet_until_key_for(job, resource_id)
+            "limiter:debounce:#{job.class.name}:#{resource_id}:quiet_until"
           end
 
-          def debounce_scheduled_key_for(job, resource_id)
-            "limiter:debounce:#{job.class.name}:#{resource_id}:scheduled"
+          def debounce_is_job_scheduled_key_for(job, resource_id)
+            "limiter:debounce:#{job.class.name}:#{resource_id}:is_job_scheduled"
           end
         end
+
+        # Result of claim_debounce_execution.
+        # is_claimed: true  -> caller should execute the job now (wait_seconds == 0.0)
+        # is_claimed: false -> a newer trigger extended the window; caller should reschedule for wait_seconds later
+        DebounceClaim = Struct.new(:is_claimed, :wait_seconds)
       end
     end
   end

--- a/lib/active_job/limiter/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/limiter/queue_adapters/sidekiq_adapter.rb
@@ -4,6 +4,29 @@ module ActiveJob
   module Limiter
     module QueueAdapters
       module SidekiqAdapter
+        DEBOUNCE_TTL_BUFFER = 5
+
+        # Sets target time and atomically claims the scheduled slot (NX).
+        # Returns "OK" if this caller wins the slot, nil otherwise.
+        DEBOUNCE_TRIGGER_SCRIPT = <<~LUA.freeze
+          redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
+          return redis.call('SET', KEYS[2], '1', 'NX', 'EX', ARGV[2])
+        LUA
+
+        # Compares target to now. Clears keys and returns '' if ready to execute,
+        # or extends the scheduled key TTL and returns the target epoch if not yet.
+        DEBOUNCE_CLAIM_SCRIPT = <<~LUA.freeze
+          local target = redis.call('GET', KEYS[1])
+          if (not target) or (tonumber(target) <= tonumber(ARGV[1])) then
+            redis.call('DEL', KEYS[1])
+            redis.call('DEL', KEYS[2])
+            return ''
+          else
+            redis.call('EXPIRE', KEYS[2], math.ceil(tonumber(target) - tonumber(ARGV[1]) + tonumber(ARGV[2])))
+            return target
+          end
+        LUA
+
         class << self
           def check_lock_before_enqueue(job, expiration)
             Sidekiq.redis_pool.with do |conn|
@@ -40,6 +63,36 @@ module ActiveJob
             end
           end
 
+          # Sets the debounce target time and atomically claims the scheduled slot if not taken.
+          # Returns true iff this caller is responsible for enqueuing the delayed job.
+          def register_debounce_trigger(job, duration, resource_id)
+            target_key = debounce_target_key_for(job, resource_id)
+            scheduled_key = debounce_scheduled_key_for(job, resource_id)
+            new_target = (Time.now.to_f + duration.to_f).to_s
+            ttl = duration.to_i + DEBOUNCE_TTL_BUFFER
+
+            result = Sidekiq.redis_pool.with do |conn|
+              conn.eval(DEBOUNCE_TRIGGER_SCRIPT, keys: [target_key, scheduled_key], argv: [new_target, ttl])
+            end
+            result == 'OK'
+          end
+
+          # Atomically checks whether target time has passed. Returns :execute if it has,
+          # or the remaining Float seconds to wait if a newer trigger extended the window.
+          def claim_debounce_execution(job, resource_id)
+            target_key = debounce_target_key_for(job, resource_id)
+            scheduled_key = debounce_scheduled_key_for(job, resource_id)
+            now = Time.now.to_f
+
+            result = Sidekiq.redis_pool.with do |conn|
+              conn.eval(DEBOUNCE_CLAIM_SCRIPT, keys: [target_key, scheduled_key], argv: [now.to_s, DEBOUNCE_TTL_BUFFER.to_s])
+            end
+
+            return :execute if result.nil? || result.empty?
+
+            [result.to_f - Time.now.to_f, 0.0].max
+          end
+
           private
 
           def key_for(job)
@@ -52,6 +105,14 @@ module ActiveJob
 
           def job_arguments_for(job)
             ActiveJob::Arguments.serialize(job.arguments).to_s
+          end
+
+          def debounce_target_key_for(job, resource_id)
+            "limiter:debounce:#{job.class.name}:#{resource_id}:target"
+          end
+
+          def debounce_scheduled_key_for(job, resource_id)
+            "limiter:debounce:#{job.class.name}:#{resource_id}:scheduled"
           end
         end
       end

--- a/lib/active_job/limiter/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/limiter/queue_adapters/sidekiq_adapter.rb
@@ -90,7 +90,7 @@ module ActiveJob
 
             return DebounceClaim.new(true, 0.0) if result.nil? || result.empty?
 
-            wait_seconds = [result.to_f - Time.now.to_f, 0.0].max
+            wait_seconds = [result.to_f - now, 0.0].max
             DebounceClaim.new(false, wait_seconds)
           end
 

--- a/lib/active_job/limiter/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/limiter/queue_adapters/sidekiq_adapter.rb
@@ -4,8 +4,8 @@ module ActiveJob
   module Limiter
     module QueueAdapters
       module SidekiqAdapter
-        # seconds of buffer added to all debounce Redis key TTLs to absorb clock skew
-        DEBOUNCE_TTL_BUFFER = 5
+        # Extra TTL buffer for debounce key. Useful when Sidekiq is overloaded and jobs executed later than scheduled
+        DEBOUNCE_TTL_BUFFER = 3600 # seconds
 
         class << self
           def check_lock_before_enqueue(job, expiration)

--- a/lib/active_job/limiter/queue_adapters/test_adapter.rb
+++ b/lib/active_job/limiter/queue_adapters/test_adapter.rb
@@ -19,6 +19,14 @@ module ActiveJob
         def self.release_lock_for_job_resource(_name, _job, _resource_id)
           true
         end
+
+        def self.register_debounce_trigger(_job, _duration, _resource_id)
+          true
+        end
+
+        def self.claim_debounce_execution(_job, _resource_id)
+          :execute
+        end
       end
     end
   end

--- a/lib/active_job/limiter/queue_adapters/test_adapter.rb
+++ b/lib/active_job/limiter/queue_adapters/test_adapter.rb
@@ -25,7 +25,7 @@ module ActiveJob
         end
 
         def self.claim_debounce_execution(_job, _resource_id)
-          :execute
+          ActiveJob::Limiter::QueueAdapters::SidekiqAdapter::DebounceClaim.new(true, 0.0)
         end
       end
     end

--- a/lib/active_job/limiter/version.rb
+++ b/lib/active_job/limiter/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveJob
   module Limiter
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end

--- a/spec/active_job/limiter_debounce_spec.rb
+++ b/spec/active_job/limiter_debounce_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe ActiveJob::Limiter do
 
       # Assert
       # perform_later returns false when around_enqueue suppresses block.call
-      expect(result == false || (result.respond_to?(:job_id) && result.job_id.nil?)).to be true
+      expect(result).to be false
       expect(enqueued_jobs.size).to eq(1)
     end
   end
@@ -116,7 +116,7 @@ RSpec.describe ActiveJob::Limiter do
       result = DebouncedJob.perform_later(resource_id)
 
       # Assert
-      expect(result == false || (result.respond_to?(:job_id) && result.job_id.nil?)).to be true
+      expect(result).to be false
       expect(enqueued_jobs).to be_empty
     end
   end

--- a/spec/active_job/limiter_debounce_spec.rb
+++ b/spec/active_job/limiter_debounce_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+RSpec.describe ActiveJob::Limiter do
+  let(:debounce_duration) { 30.seconds }
+  let(:resource_id) { '456' }
+  let(:queue_name) { :default_queue }
+
+  # spec_helper only resets performed_jobs; enqueued_jobs must be cleared separately
+  before :each do
+    ActiveJob::Base.queue_adapter.enqueued_jobs = []
+  end
+
+  class DebounceMetricsProxy
+    def self.call(result, job); end
+  end
+
+  class DebouncedJob < ActiveJob::Base
+    include ActiveJob::Limiter::Mixin # Needed without Rails autoloading
+
+    # Same as :queue_name above, unable to access let()
+    queue_as :default_queue
+
+    # Same as :debounce_duration above, unable to access let()
+    debounce_job(
+      duration: 30.seconds,
+      extract_resource_id: ->(job) { job.arguments.first },
+      metrics_hook: DebounceMetricsProxy
+    )
+
+    def perform(resource_id); end
+  end
+
+  class StandardDebounceJob < ActiveJob::Base
+    include ActiveJob::Limiter::Mixin # Needed without Rails autoloading
+
+    def perform; end
+  end
+
+  # Preconditions
+
+  def trigger_claims_slot
+    expect(ActiveJob::Limiter).to receive(:register_debounce_trigger)
+      .with(instance_of(DebouncedJob), debounce_duration, resource_id).and_return(true)
+  end
+
+  def trigger_slot_already_taken
+    expect(ActiveJob::Limiter).to receive(:register_debounce_trigger)
+      .with(instance_of(DebouncedJob), debounce_duration, resource_id).and_return(false)
+  end
+
+  def execution_claim_succeeds
+    expect(ActiveJob::Limiter).to receive(:claim_debounce_execution)
+      .with(instance_of(DebouncedJob), resource_id).and_return(:execute)
+  end
+
+  def execution_claim_needs_reschedule(remaining_wait)
+    expect(ActiveJob::Limiter).to receive(:claim_debounce_execution)
+      .with(instance_of(DebouncedJob), resource_id).and_return(remaining_wait)
+  end
+
+  # Expectations
+
+  def job_should_be_performed
+    expect_any_instance_of(DebouncedJob).to receive(:perform).with(resource_id)
+  end
+
+  def job_should_not_be_performed
+    expect_any_instance_of(DebouncedJob).to_not receive(:perform).with(resource_id)
+  end
+
+  def expect_metric(result)
+    expect(DebounceMetricsProxy).to receive(:call).with(result, instance_of(DebouncedJob))
+  end
+
+  # Simulates the internal delayed job waking up: enqueued without wait: so perform_enqueued_jobs=true
+  # causes it to execute immediately, triggering around_perform.
+  def trigger_perform_phase(queue: :default_queue)
+    job = DebouncedJob.new(resource_id)
+    job.instance_variable_set(:@bypass_active_job_limiter_debounce, true)
+    job.enqueue(queue: queue)
+  end
+
+  # around_enqueue: exercised via perform_later
+
+  context 'first trigger in a burst (slot claimed)' do
+    before :each do
+      trigger_claims_slot
+    end
+
+    it 'enqueues one internal delayed job and emits scheduled metric' do
+      expect_metric('enqueue.scheduled')
+
+      result = DebouncedJob.perform_later(resource_id)
+      # perform_later returns false when around_enqueue suppresses block.call
+      expect(result == false || (result.respond_to?(:job_id) && result.job_id.nil?)).to be true
+      expect(enqueued_jobs.size).to eq(1)
+    end
+  end
+
+  context 'subsequent trigger during burst (slot already taken)' do
+    before :each do
+      trigger_slot_already_taken
+    end
+
+    it 'coalesces the trigger: no new job enqueued, emits coalesced metric' do
+      expect_metric('enqueue.coalesced')
+
+      result = DebouncedJob.perform_later(resource_id)
+      expect(result == false || (result.respond_to?(:job_id) && result.job_id.nil?)).to be true
+      expect(enqueued_jobs).to be_empty
+    end
+  end
+
+  # around_perform: exercised by enqueueing a bypass job without wait so it runs immediately
+
+  context 'scheduled job wakes up and target time has passed' do
+    before :each do
+      execution_claim_succeeds
+    end
+
+    it 'performs the job and emits performed metric' do
+      job_should_be_performed
+      expect_metric('perform.performed')
+
+      trigger_perform_phase
+    end
+  end
+
+  context 'scheduled job wakes up but a newer trigger has extended the target' do
+    let(:remaining_wait) { 15.0 }
+
+    before :each do
+      execution_claim_needs_reschedule(remaining_wait)
+    end
+
+    it 'reschedules a new delayed job, does not perform, emits rescheduled metric' do
+      job_should_not_be_performed
+      expect_metric('perform.rescheduled')
+
+      expect { trigger_perform_phase }.to change { enqueued_jobs.size }.by(1)
+    end
+
+    context 'when queue is explicitly set' do
+      let(:queue_name) { :a_different_queue }
+
+      it 'preserves the queue name on the rescheduled job' do
+        job_should_not_be_performed
+        allow(DebounceMetricsProxy).to receive(:call)
+
+        trigger_perform_phase(queue: queue_name)
+
+        expect(enqueued_jobs.last['queue_name']).to eq(queue_name.to_s)
+      end
+    end
+  end
+
+  context 'bypass flag set (internal scheduled/rescheduled job passing through enqueue)' do
+    before :each do
+      execution_claim_succeeds
+    end
+
+    it 'enqueues and performs normally without calling register_debounce_trigger' do
+      expect(ActiveJob::Limiter).to_not receive(:register_debounce_trigger)
+      job_should_be_performed
+      allow(DebounceMetricsProxy).to receive(:call)
+
+      trigger_perform_phase
+    end
+  end
+
+  context 'extract_resource_id lambda' do
+    it 'receives the full job object with its arguments' do
+      received_job = nil
+      job_class = Class.new(ActiveJob::Base) do
+        include ActiveJob::Limiter::Mixin
+
+        debounce_job(
+          duration: 10.seconds,
+          extract_resource_id: lambda { |j|
+            received_job = j
+            j.arguments.first
+          }
+        )
+
+        def perform(resource_id); end
+      end
+
+      allow(ActiveJob::Limiter).to receive(:register_debounce_trigger).and_return(true)
+
+      job_class.perform_later('my-resource')
+
+      expect(received_job).to be_a(job_class)
+      expect(received_job.arguments).to eq(['my-resource'])
+    end
+  end
+
+  context 'job without debounce_job directive' do
+    it 'is unaffected — no debounce methods called' do
+      expect(ActiveJob::Limiter).to_not receive(:register_debounce_trigger)
+      expect(ActiveJob::Limiter).to_not receive(:claim_debounce_execution)
+      expect_any_instance_of(StandardDebounceJob).to receive(:perform)
+
+      StandardDebounceJob.perform_later
+    end
+  end
+end

--- a/spec/active_job/limiter_debounce_spec.rb
+++ b/spec/active_job/limiter_debounce_spec.rb
@@ -30,41 +30,43 @@ RSpec.describe ActiveJob::Limiter do
     def perform(resource_id); end
   end
 
-  class StandardDebounceJob < ActiveJob::Base
+  class StandardJob < ActiveJob::Base
     include ActiveJob::Limiter::Mixin # Needed without Rails autoloading
 
     def perform; end
   end
 
-  # Preconditions
+  # Mocks (preconditions)
 
-  def trigger_claims_slot
+  def mock_trigger_claims_slot
     expect(ActiveJob::Limiter).to receive(:register_debounce_trigger)
       .with(instance_of(DebouncedJob), debounce_duration, resource_id).and_return(true)
   end
 
-  def trigger_slot_already_taken
+  def mock_trigger_slot_already_taken
     expect(ActiveJob::Limiter).to receive(:register_debounce_trigger)
       .with(instance_of(DebouncedJob), debounce_duration, resource_id).and_return(false)
   end
 
-  def execution_claim_succeeds
+  def mock_execution_claim_succeeds
     expect(ActiveJob::Limiter).to receive(:claim_debounce_execution)
-      .with(instance_of(DebouncedJob), resource_id).and_return(:execute)
+      .with(instance_of(DebouncedJob), resource_id)
+      .and_return(ActiveJob::Limiter::QueueAdapters::SidekiqAdapter::DebounceClaim.new(true, 0.0))
   end
 
-  def execution_claim_needs_reschedule(remaining_wait)
+  def mock_execution_claim_needs_reschedule(remaining_wait)
     expect(ActiveJob::Limiter).to receive(:claim_debounce_execution)
-      .with(instance_of(DebouncedJob), resource_id).and_return(remaining_wait)
+      .with(instance_of(DebouncedJob), resource_id)
+      .and_return(ActiveJob::Limiter::QueueAdapters::SidekiqAdapter::DebounceClaim.new(false, remaining_wait))
   end
 
   # Expectations
 
-  def job_should_be_performed
+  def expect_job_performed
     expect_any_instance_of(DebouncedJob).to receive(:perform).with(resource_id)
   end
 
-  def job_should_not_be_performed
+  def expect_job_not_performed
     expect_any_instance_of(DebouncedJob).to_not receive(:perform).with(resource_id)
   end
 
@@ -84,13 +86,17 @@ RSpec.describe ActiveJob::Limiter do
 
   context 'first trigger in a burst (slot claimed)' do
     before :each do
-      trigger_claims_slot
+      mock_trigger_claims_slot
     end
 
     it 'enqueues one internal delayed job and emits scheduled metric' do
+      # Arrange
       expect_metric('enqueue.scheduled')
 
+      # Act
       result = DebouncedJob.perform_later(resource_id)
+
+      # Assert
       # perform_later returns false when around_enqueue suppresses block.call
       expect(result == false || (result.respond_to?(:job_id) && result.job_id.nil?)).to be true
       expect(enqueued_jobs.size).to eq(1)
@@ -99,13 +105,17 @@ RSpec.describe ActiveJob::Limiter do
 
   context 'subsequent trigger during burst (slot already taken)' do
     before :each do
-      trigger_slot_already_taken
+      mock_trigger_slot_already_taken
     end
 
     it 'coalesces the trigger: no new job enqueued, emits coalesced metric' do
+      # Arrange
       expect_metric('enqueue.coalesced')
 
+      # Act
       result = DebouncedJob.perform_later(resource_id)
+
+      # Assert
       expect(result == false || (result.respond_to?(:job_id) && result.job_id.nil?)).to be true
       expect(enqueued_jobs).to be_empty
     end
@@ -115,13 +125,15 @@ RSpec.describe ActiveJob::Limiter do
 
   context 'scheduled job wakes up and target time has passed' do
     before :each do
-      execution_claim_succeeds
+      mock_execution_claim_succeeds
     end
 
     it 'performs the job and emits performed metric' do
-      job_should_be_performed
+      # Arrange
+      expect_job_performed
       expect_metric('perform.performed')
 
+      # Act + Assert
       trigger_perform_phase
     end
   end
@@ -130,13 +142,15 @@ RSpec.describe ActiveJob::Limiter do
     let(:remaining_wait) { 15.0 }
 
     before :each do
-      execution_claim_needs_reschedule(remaining_wait)
+      mock_execution_claim_needs_reschedule(remaining_wait)
     end
 
     it 'reschedules a new delayed job, does not perform, emits rescheduled metric' do
-      job_should_not_be_performed
+      # Arrange
+      expect_job_not_performed
       expect_metric('perform.rescheduled')
 
+      # Act + Assert
       expect { trigger_perform_phase }.to change { enqueued_jobs.size }.by(1)
     end
 
@@ -144,11 +158,14 @@ RSpec.describe ActiveJob::Limiter do
       let(:queue_name) { :a_different_queue }
 
       it 'preserves the queue name on the rescheduled job' do
-        job_should_not_be_performed
+        # Arrange
+        expect_job_not_performed
         allow(DebounceMetricsProxy).to receive(:call)
 
+        # Act
         trigger_perform_phase(queue: queue_name)
 
+        # Assert
         expect(enqueued_jobs.last['queue_name']).to eq(queue_name.to_s)
       end
     end
@@ -156,20 +173,23 @@ RSpec.describe ActiveJob::Limiter do
 
   context 'bypass flag set (internal scheduled/rescheduled job passing through enqueue)' do
     before :each do
-      execution_claim_succeeds
+      mock_execution_claim_succeeds
     end
 
     it 'enqueues and performs normally without calling register_debounce_trigger' do
+      # Arrange
       expect(ActiveJob::Limiter).to_not receive(:register_debounce_trigger)
-      job_should_be_performed
+      expect_job_performed
       allow(DebounceMetricsProxy).to receive(:call)
 
+      # Act + Assert
       trigger_perform_phase
     end
   end
 
   context 'extract_resource_id lambda' do
     it 'receives the full job object with its arguments' do
+      # Arrange
       received_job = nil
       job_class = Class.new(ActiveJob::Base) do
         include ActiveJob::Limiter::Mixin
@@ -187,8 +207,10 @@ RSpec.describe ActiveJob::Limiter do
 
       allow(ActiveJob::Limiter).to receive(:register_debounce_trigger).and_return(true)
 
+      # Act
       job_class.perform_later('my-resource')
 
+      # Assert
       expect(received_job).to be_a(job_class)
       expect(received_job.arguments).to eq(['my-resource'])
     end
@@ -196,11 +218,13 @@ RSpec.describe ActiveJob::Limiter do
 
   context 'job without debounce_job directive' do
     it 'is unaffected — no debounce methods called' do
+      # Arrange
       expect(ActiveJob::Limiter).to_not receive(:register_debounce_trigger)
       expect(ActiveJob::Limiter).to_not receive(:claim_debounce_execution)
-      expect_any_instance_of(StandardDebounceJob).to receive(:perform)
+      expect_any_instance_of(StandardJob).to receive(:perform)
 
-      StandardDebounceJob.perform_later
+      # Act + Assert
+      StandardJob.perform_later
     end
   end
 end

--- a/spec/active_job/sidekiq_adapter_debounce_spec.rb
+++ b/spec/active_job/sidekiq_adapter_debounce_spec.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+require 'sidekiq'
+
+REDIS_TEST_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6389/0')
+
+Sidekiq.configure_client { |cfg| cfg.redis = { url: REDIS_TEST_URL } }
+Sidekiq.configure_server { |cfg| cfg.redis = { url: REDIS_TEST_URL } }
+
 RSpec.describe ActiveJob::Limiter::QueueAdapters::SidekiqAdapter do
   let(:adapter) { described_class }
   let(:resource_id) { '567' }

--- a/spec/active_job/sidekiq_adapter_debounce_spec.rb
+++ b/spec/active_job/sidekiq_adapter_debounce_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+RSpec.describe ActiveJob::Limiter::QueueAdapters::SidekiqAdapter do
+  let(:adapter) { described_class }
+  let(:resource_id) { '567' }
+  let(:duration) { 30 }
+
+  # A minimal job class whose name is stable across examples
+  let(:job_class) do
+    Class.new(ActiveJob::Base) do
+      def self.name
+        'TestAdapterJob'
+      end
+
+      def perform(*)
+        ;
+      end
+    end
+  end
+
+  let(:job) { job_class.new('arg1') }
+
+  # Helpers to absorb wall-clock drift between Ruby and Redis in tests
+  TIMING_TOLERANCE = 1 # seconds
+  def be_approximately(expected)
+    be_between(expected - TIMING_TOLERANCE, expected + TIMING_TOLERANCE)
+  end
+
+  def be_approximately_before(expected)
+    be_between(expected - TIMING_TOLERANCE, expected)
+  end
+
+  before(:each) do
+    Sidekiq.redis { |c| c.flushdb }
+  end
+
+  describe "debounce" do
+    let(:quiet_until_key) { "limiter:debounce:#{job_class.name}:#{resource_id}:quiet_until" }
+    let(:is_job_scheduled_key) { "limiter:debounce:#{job_class.name}:#{resource_id}:is_job_scheduled" }
+
+    describe '#register_debounce_trigger' do
+      it 'returns true on the first trigger and creates both keys' do
+        result = adapter.register_debounce_trigger(job, duration, resource_id)
+        expect(result).to be true
+
+        Sidekiq.redis do |c|
+          quiet_until = c.get(quiet_until_key)
+          scheduled = c.get(is_job_scheduled_key)
+          expect(quiet_until.to_f).to be_approximately(Time.now.to_f + duration)
+          expect(scheduled).to eq('1')
+        end
+      end
+
+      it 'returns false on subsequent triggers (slot already taken)' do
+        adapter.register_debounce_trigger(job, duration, resource_id)
+        expect(adapter.register_debounce_trigger(job, duration, resource_id)).to be false
+      end
+
+      it 'slides quiet_until forward on each trigger' do
+        adapter.register_debounce_trigger(job, duration, resource_id)
+        first_quiet_until = Sidekiq.redis { |c| c.get(quiet_until_key).to_f }
+
+        sleep(0.01)
+        adapter.register_debounce_trigger(job, duration, resource_id)
+        second_quiet_until = Sidekiq.redis { |c| c.get(quiet_until_key).to_f }
+
+        expect(second_quiet_until).to be > first_quiet_until
+      end
+
+      it 'sets TTL on both keys equal to duration' do
+        expected_ttl = duration + described_class::DEBOUNCE_TTL_BUFFER
+        adapter.register_debounce_trigger(job, duration, resource_id)
+
+        Sidekiq.redis do |c|
+          quiet_until_ttl = c.ttl(quiet_until_key)
+          scheduled_ttl = c.ttl(is_job_scheduled_key)
+          expect(quiet_until_ttl).to be_approximately_before(expected_ttl)
+          expect(scheduled_ttl).to be_approximately_before(expected_ttl)
+        end
+      end
+
+      it 'does not refresh the scheduled key TTL on subsequent triggers' do
+        adapter.register_debounce_trigger(job, duration, resource_id)
+        Sidekiq.redis { |c| c.expire(is_job_scheduled_key, 10) } # manually lower TTL
+
+        adapter.register_debounce_trigger(job, duration, resource_id)
+
+        Sidekiq.redis do |c|
+          expect(c.ttl(is_job_scheduled_key)).to be_approximately_before(10)
+        end
+      end
+    end
+
+    describe '#claim_debounce_execution' do
+      context 'when quiet_until key is absent' do
+        it 'returns a claimed DebounceClaim and leaves no keys' do
+          claim = adapter.claim_debounce_execution(job, resource_id)
+          expect(claim.is_claimed).to be true
+          expect(claim.wait_seconds).to eq(0.0)
+        end
+      end
+
+      context 'when quiet_until is in the past' do
+        before do
+          Sidekiq.redis do |c|
+            c.set(quiet_until_key, (Time.now.to_f - 1).to_s, ex: 60)
+            c.set(is_job_scheduled_key, '1', ex: 60)
+          end
+        end
+
+        it 'returns a claimed DebounceClaim' do
+          claim = adapter.claim_debounce_execution(job, resource_id)
+          expect(claim.is_claimed).to be true
+          expect(claim.wait_seconds).to eq(0.0)
+        end
+
+        it 'deletes both keys' do
+          adapter.claim_debounce_execution(job, resource_id)
+          Sidekiq.redis do |c|
+            expect(c.exists(quiet_until_key)).to eq(0)
+            expect(c.exists(is_job_scheduled_key)).to eq(0)
+          end
+        end
+      end
+
+      context 'when quiet_until is in the future' do
+        let(:future_epoch) { Time.now.to_f + 15 }
+
+        before do
+          Sidekiq.redis do |c|
+            c.set(quiet_until_key, future_epoch.to_s, ex: 60)
+            c.set(is_job_scheduled_key, '1', ex: 10)
+          end
+        end
+
+        it 'returns an unclaimed DebounceClaim with wait_seconds approximating remaining time' do
+          claim = adapter.claim_debounce_execution(job, resource_id)
+          expect(claim.is_claimed).to be false
+          expect(claim.wait_seconds).to be_approximately(future_epoch - Time.now.to_f)
+        end
+
+        it 'extends the is_job_scheduled TTL to approximately remaining time + DEBOUNCE_TTL_BUFFER' do
+          adapter.claim_debounce_execution(job, resource_id)
+          expected_ttl = (future_epoch - Time.now.to_f + described_class::DEBOUNCE_TTL_BUFFER).ceil
+          Sidekiq.redis do |c|
+            expect(c.ttl(is_job_scheduled_key)).to be_approximately_before(expected_ttl)
+          end
+        end
+
+        it 'keeps both keys alive' do
+          adapter.claim_debounce_execution(job, resource_id)
+          Sidekiq.redis do |c|
+            expect(c.exists(quiet_until_key)).to eq(1)
+            expect(c.exists(is_job_scheduled_key)).to eq(1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,12 @@ require 'bundler/setup'
 require 'active_job'
 require 'active_job/limiter'
 require 'byebug'
+require 'sidekiq'
+
+REDIS_TEST_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6389/0')
+
+Sidekiq.configure_client { |cfg| cfg.redis = { url: REDIS_TEST_URL } }
+Sidekiq.configure_server { |cfg| cfg.redis = { url: REDIS_TEST_URL } }
 
 RSpec.configure do |config|
   config.include(ActiveJob::TestHelper)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,12 +4,6 @@ require 'bundler/setup'
 require 'active_job'
 require 'active_job/limiter'
 require 'byebug'
-require 'sidekiq'
-
-REDIS_TEST_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6389/0')
-
-Sidekiq.configure_client { |cfg| cfg.redis = { url: REDIS_TEST_URL } }
-Sidekiq.configure_server { |cfg| cfg.redis = { url: REDIS_TEST_URL } }
 
 RSpec.configure do |config|
   config.include(ActiveJob::TestHelper)


### PR DESCRIPTION
## What

Adds `debounce_job` as a third enqueue-control primitive alongside `limit_queue` and `throttle_job`.

Trailing-edge debounce semantics: for any burst of `perform_later` triggers on a given resource, exactly one execution fires after `duration` has elapsed since the **last** trigger. Coalesces the burst rather than firing on the leading edge.

**How it works:**
- Every `perform_later` is a trigger, not a direct enqueue (`job_id` is set to `nil`).
- The first trigger in a burst atomically claims a scheduled slot in Redis and enqueues one internal delayed job (`duration` from now).
- Subsequent triggers overwrite the target epoch in Redis (`quiet_until`) and are dropped — no additional Sidekiq job.
- When the delayed job wakes up, check the `quiet_until`: if it has passed, execute; if a newer trigger extended it, reschedule and drop.

Atomicity is guaranteed by two Lua scripts in `SidekiqAdapter` to prevent races between concurrent triggers.

**Version bump:** `0.1.1` → `0.2.0`
**Testing setup:** Added testing Sidekiq adapter against actual Redis

## Why

Throttle fires on the leading edge; debounce fires on the trailing edge. This is the right primitive for workflows where you want to act once after a burst settles — search re-indexing after rapid model updates, webhook flood collapsing, etc.